### PR TITLE
Fix tailwind plugin import

### DIFF
--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from 'tailwindcss';
+import daisyui from 'daisyui';
 
 const config: Config = {
   darkMode: 'class',
@@ -14,7 +15,7 @@ const config: Config = {
       },
     },
   },
-  plugins: [require('daisyui')],
+  plugins: [daisyui],
   daisyui: {
     themes: true,
   },


### PR DESCRIPTION
## Summary
- fix import syntax for DaisyUI plugin in `tailwind.config.ts`

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'daisyui', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6841521809c4832aaed3114ee8beb225