### PR TITLE
Fix DaisyUI type error in build

### DIFF
--- a/daisyui.d.ts
+++ b/daisyui.d.ts
@@ -1,0 +1,1 @@
+declare module 'daisyui';


### PR DESCRIPTION
## Summary
- declare DaisyUI module to satisfy TypeScript

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68416a1a151c832aa7634f1c28bdf87d