### PR TITLE
Add enriched country details

### DIFF
--- a/src/app/api/countries/[name]/route.ts
+++ b/src/app/api/countries/[name]/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from 'next/server';
+
+export async function GET(
+  _req: Request,
+  { params }: { params: { name: string } }
+) {
+  try {
+    const name = decodeURIComponent(params.name);
+    const res = await fetch(
+      `https://restcountries.com/v3.1/name/${encodeURIComponent(name)}?fullText=true`
+    );
+    if (!res.ok) {
+      return NextResponse.json({ error: 'Country not found' }, { status: res.status });
+    }
+    const data = await res.json();
+    const country = data[0];
+    const detail = {
+      name: country.name?.common ?? name,
+      flag: country.flags?.png || '',
+      capital: country.capital?.[0] || 'N/A',
+      population: country.population,
+      region: country.region,
+      subregion: country.subregion,
+      area: country.area,
+      languages: country.languages,
+      borders: country.borders,
+      currencies: country.currencies,
+      timezones: country.timezones,
+    };
+    return NextResponse.json(detail);
+  } catch (err) {
+    return NextResponse.json({ error: 'Failed to fetch' }, { status: 500 });
+  }
+}

--- a/src/app/countries/[name]/page.tsx
+++ b/src/app/countries/[name]/page.tsx
@@ -13,20 +13,19 @@ type Country = {
     subregion?: string;
     borders?: string[];
     area?: number;
+    currencies?: Record<string, { name: string; symbol: string }>;
+    timezones?: string[];
 };
 
 export const dynamic = 'force-dynamic'; // enable runtime rendering
 
 export default async function CountryPage({ params }: { params: Promise<{ name: string }> }) {
     const { name } = await params;
-    const res = await fetch(`${process.env.NEXT_PUBLIC_SITE_URL}/api/countries`);
-    const allCountries: Country[] = await res.json();
-
-    const country = allCountries.find(
-        (c) => c.name.toLowerCase() === decodeURIComponent(name).toLowerCase()
+    const res = await fetch(
+        `${process.env.NEXT_PUBLIC_SITE_URL}/api/countries/${encodeURIComponent(name)}`
     );
-
-    if (!country) return notFound();
+    if (!res.ok) return notFound();
+    const country: Country = await res.json();
 
     return (
         <main className="max-w-4xl mx-auto py-10 px-4 space-y-6">
@@ -50,6 +49,17 @@ export default async function CountryPage({ params }: { params: Promise<{ name: 
                     {country.area && <p><strong>Area:</strong> {country.area.toLocaleString()} km²</p>}
                     {country.borders?.length && (
                         <p><strong>Borders:</strong> {country.borders.join(', ')}</p>
+                    )}
+                    {country.currencies && (
+                        <p>
+                            <strong>Currencies:</strong>{' '}
+                            {Object.values(country.currencies)
+                                .map((c) => c.name)
+                                .join(', ')}
+                        </p>
+                    )}
+                    {country.timezones && (
+                        <p><strong>Timezones:</strong> {country.timezones.join(', ')}</p>
                     )}
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- add new API route to fetch detailed country info
- refactor country details page to use new API
- display currencies and timezones

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68419993daa4832a98fab071f5205562