### PR TITLE
Fix invalid country data handling

### DIFF
--- a/src/app/countries/[name]/page.tsx
+++ b/src/app/countries/[name]/page.tsx
@@ -20,7 +20,15 @@ export const dynamic = 'force-dynamic'; // enable runtime rendering
 export default async function CountryPage({ params }: { params: Promise<{ name: string }> }) {
     const { name } = await params;
     const res = await fetch(`${process.env.NEXT_PUBLIC_SITE_URL}/api/countries`);
-    const allCountries: Country[] = await res.json();
+    let allCountries: Country[] = [];
+    try {
+        const data = await res.json();
+        if (Array.isArray(data)) {
+            allCountries = data;
+        }
+    } catch (err) {
+        console.error('Error loading countries', err);
+    }
 
     const country = allCountries.find(
         (c) => c.name.toLowerCase() === decodeURIComponent(name).toLowerCase()

--- a/src/components/CountriesList.tsx
+++ b/src/components/CountriesList.tsx
@@ -20,7 +20,18 @@ export default function CountriesList() {
     useEffect(() => {
         fetch('/api/countries')
             .then((res) => res.json())
-            .then((data) => setCountries(data));
+            .then((data) => {
+                if (Array.isArray(data)) {
+                    setCountries(data);
+                } else {
+                    console.error('Failed to load countries', data);
+                    setCountries([]);
+                }
+            })
+            .catch((err) => {
+                console.error('Error fetching countries', err);
+                setCountries([]);
+            });
     }, []);
 
     const filtered = countries.filter((c) =>


### PR DESCRIPTION
## Summary
- safeguard CountriesList against API errors
- check API data on Country details page

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841e0c23480832a8e8b26eedc89ba80