### PR TITLE
Fix API fallback for production

### DIFF
--- a/src/app/api/countries/route.ts
+++ b/src/app/api/countries/route.ts
@@ -1,19 +1,25 @@
 import { NextResponse } from 'next/server';
+import fallbackCountries from '@/data/countries.json';
 
 export async function GET() {
   try {
     const res = await fetch('https://restcountries.com/v3.1/all');
-    const data = await res.json();
-    const simplified = data.map((country: any) => ({
-      name: country.name.common,
-      flag: country.flags?.png || '',
-      capital: country.capital?.[0] || 'N/A',
-      population: country.population,
-      region: country.region,
-      languages: country.languages,
-    }));
-    return NextResponse.json(simplified);
+    if (res.ok) {
+      const data = await res.json();
+      const simplified = data.map((country: any) => ({
+        name: country.name.common,
+        flag: country.flags?.png || '',
+        capital: country.capital?.[0] || 'N/A',
+        population: country.population,
+        region: country.region,
+        languages: country.languages,
+      }));
+      return NextResponse.json(simplified);
+    }
   } catch (err) {
-    return NextResponse.json({ error: 'Failed to fetch' }, { status: 500 });
+    console.error('Failed fetching remote countries:', err);
   }
+
+  // Fallback to bundled sample data
+  return NextResponse.json(fallbackCountries);
 }

--- a/src/app/countries/[name]/page.tsx
+++ b/src/app/countries/[name]/page.tsx
@@ -19,7 +19,9 @@ export const dynamic = 'force-dynamic'; // enable runtime rendering
 
 export default async function CountryPage({ params }: { params: Promise<{ name: string }> }) {
     const { name } = await params;
-    const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000';
+    const baseUrl =
+        process.env.NEXT_PUBLIC_SITE_URL ||
+        (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : 'http://localhost:3000');
     const res = await fetch(`${baseUrl}/api/countries`);
     let allCountries: Country[] = [];
     try {

--- a/src/app/countries/[name]/page.tsx
+++ b/src/app/countries/[name]/page.tsx
@@ -2,6 +2,7 @@
 // app/countries/[name]/page.tsx
 import { notFound } from 'next/navigation';
 import Image from 'next/image';
+import { getBaseUrl } from '@/lib/getBaseUrl';
 
 type Country = {
     name: string;
@@ -19,9 +20,7 @@ export const dynamic = 'force-dynamic'; // enable runtime rendering
 
 export default async function CountryPage({ params }: { params: Promise<{ name: string }> }) {
     const { name } = await params;
-    const baseUrl =
-        process.env.NEXT_PUBLIC_SITE_URL ||
-        (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : 'http://localhost:3000');
+    const baseUrl = getBaseUrl();
     const res = await fetch(`${baseUrl}/api/countries`);
     let allCountries: Country[] = [];
     try {

--- a/src/app/countries/[name]/page.tsx
+++ b/src/app/countries/[name]/page.tsx
@@ -19,8 +19,17 @@ export const dynamic = 'force-dynamic'; // enable runtime rendering
 
 export default async function CountryPage({ params }: { params: Promise<{ name: string }> }) {
     const { name } = await params;
-    const res = await fetch(`${process.env.NEXT_PUBLIC_SITE_URL}/api/countries`);
-    const allCountries: Country[] = await res.json();
+    const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000';
+    const res = await fetch(`${baseUrl}/api/countries`);
+    let allCountries: Country[] = [];
+    try {
+        const data = await res.json();
+        if (Array.isArray(data)) {
+            allCountries = data;
+        }
+    } catch (err) {
+        console.error('Error loading countries', err);
+    }
 
     const country = allCountries.find(
         (c) => c.name.toLowerCase() === decodeURIComponent(name).toLowerCase()

--- a/src/components/CountriesList.tsx
+++ b/src/components/CountriesList.tsx
@@ -19,8 +19,24 @@ export default function CountriesList() {
 
     useEffect(() => {
         fetch('/api/countries')
-            .then((res) => res.json())
-            .then((data) => setCountries(data));
+            .then((res) => {
+                if (!res.ok) {
+                    throw new Error('Request failed');
+                }
+                return res.json();
+            })
+            .then((data) => {
+                if (Array.isArray(data)) {
+                    setCountries(data);
+                } else {
+                    console.error('Failed to load countries', data);
+                    setCountries([]);
+                }
+            })
+            .catch((err) => {
+                console.error('Error fetching countries', err);
+                setCountries([]);
+            });
     }, []);
 
     const filtered = countries.filter((c) =>

--- a/src/data/countries.json
+++ b/src/data/countries.json
@@ -1,0 +1,42 @@
+[
+  {
+    "name": "United States",
+    "flag": "https://flagcdn.com/us.svg",
+    "capital": "Washington D.C.",
+    "population": 331002651,
+    "region": "Americas",
+    "languages": {"eng": "English"}
+  },
+  {
+    "name": "Canada",
+    "flag": "https://flagcdn.com/ca.svg",
+    "capital": "Ottawa",
+    "population": 38005238,
+    "region": "Americas",
+    "languages": {"eng": "English", "fra": "French"}
+  },
+  {
+    "name": "Germany",
+    "flag": "https://flagcdn.com/de.svg",
+    "capital": "Berlin",
+    "population": 83240525,
+    "region": "Europe",
+    "languages": {"deu": "German"}
+  },
+  {
+    "name": "Japan",
+    "flag": "https://flagcdn.com/jp.svg",
+    "capital": "Tokyo",
+    "population": 125836021,
+    "region": "Asia",
+    "languages": {"jpn": "Japanese"}
+  },
+  {
+    "name": "Brazil",
+    "flag": "https://flagcdn.com/br.svg",
+    "capital": "Brasília",
+    "population": 212559417,
+    "region": "Americas",
+    "languages": {"por": "Portuguese"}
+  }
+]

--- a/src/lib/getBaseUrl.ts
+++ b/src/lib/getBaseUrl.ts
@@ -1,0 +1,15 @@
+import { headers } from 'next/headers';
+
+export function getBaseUrl() {
+  const env =
+    process.env.NEXT_PUBLIC_SITE_URL ||
+    (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : '');
+  if (env) return env;
+  const h = headers();
+  const host = h.get('x-forwarded-host') || h.get('host');
+  if (host) {
+    const protocol = host.includes('localhost') ? 'http' : 'https';
+    return `${protocol}://${host}`;
+  }
+  return 'http://localhost:3000';
+}


### PR DESCRIPTION
## Summary
- bundle sample countries data with the API route
- use bundled data when the remote fetch fails
- fix country detail page to use a default base URL
- harden country list fetch handling

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841e0c23480832a8e8b26eedc89ba80