### PR TITLE
Fix PWA manifest integration

### DIFF
--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -19,6 +19,7 @@
         "type": "image/png"
       }
     ],
+    "start_url": "/",
     "theme_color": "#1e3a8a",
     "background_color": "#ffffff",
     "display": "standalone"

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -9,6 +9,8 @@ const inter = Inter({ subsets: ['latin'], variable: '--font-inter' });
 export const metadata: Metadata = {
   title: 'Countries Explorer',
   description: 'Search and explore countries using the REST Countries API',
+  manifest: '/site.webmanifest',
+  themeColor: '#1e3a8a',
 };
 
 export default function RootLayout({


### PR DESCRIPTION
## Summary
- link webmanifest in app metadata and define theme color
- add start_url to the PWA manifest

## Testing
- `npm install`
- `npm run build` *(fails: Failed to fetch `Inter` font)*

------
https://chatgpt.com/codex/tasks/task_e_68499f0ccc58832aa8496e93cf1249de